### PR TITLE
[MET-9] Update password for user authenticated

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js','*'],
+  ignorePatterns: ['.eslintrc.js'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,9 @@
 import { AuthService } from './auth.service';
-import { Body, Controller, Post } from '@nestjs/common';
-import { CreateUserDto, LoginUserDto } from './dto';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { CreateUserDto, LoginUserDto, UpdatePasswordAuthDto } from './dto';
+import { CurrentUser } from './decorators';
+import { User } from '../user/entities/user.entity';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -15,5 +18,14 @@ export class AuthController {
   @Post('login')
   login(@Body() loginUserDto: LoginUserDto) {
     return this.authService.login(loginUserDto);
+  }
+
+  @Post('update-password')
+  @UseGuards(JwtAuthGuard)
+  updatePassword(
+    @Body() updateUserPasswordDto: UpdatePasswordAuthDto,
+    @CurrentUser() user: User,
+  ): any {
+    return this.authService.updatePassword(updateUserPasswordDto, user.id);
   }
 }

--- a/src/auth/dto/index.ts
+++ b/src/auth/dto/index.ts
@@ -1,4 +1,3 @@
 export { CreateUserDto } from './create-user.dto';
 export { LoginUserDto } from './login-user.dto';
-export { UpdateAuthDto } from './update-auth.dto';
-
+export { UpdatePasswordAuthDto } from './update-password-auth.dto';

--- a/src/auth/dto/update-auth.dto.ts
+++ b/src/auth/dto/update-auth.dto.ts
@@ -1,8 +1,0 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateUserDto } from './create-user.dto';
-import { Field } from '@nestjs/graphql';
-
-export class UpdateAuthDto extends PartialType(CreateUserDto) {
-    @Field(() => String)
-  id: string;
-}

--- a/src/auth/dto/update-password-auth.dto.ts
+++ b/src/auth/dto/update-password-auth.dto.ts
@@ -1,0 +1,22 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateUserDto } from './create-user.dto';
+import { Field } from '@nestjs/graphql';
+import { IsString, Matches } from 'class-validator';
+
+export class UpdatePasswordAuthDto extends PartialType(CreateUserDto) {
+  @IsString()
+  @Matches(/(?:(?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/, {
+    message:
+      'The password must have a Uppercase, lowercase letter and a number',
+  })
+  @Field(() => String)
+  newPassword: string;
+
+  @IsString()
+  @Matches(/(?:(?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/, {
+    message:
+      'The password must have a Uppercase, lowercase letter and a number',
+  })
+  @Field(() => String)
+  confirmPassword: string;
+}


### PR DESCRIPTION
Se crea este **PR** por el motivo de una nueva funcionalidad del cambio de contraseña del usuario autenticado con el endpoint en modo de desarrollo “[localhost:3001/auth/update-password](http://localhost:3001/auth/update-password)” solicitando en formato **JSON**
```json
{
    "password": "Aa123456.",
    "newPassword": "Bc2468.",
    "confirmPassword": "Bc2468."
}
```
Con los posibles errores:
```json
{
    "message": [
        "Su contraseña actual no coincide"
    ],
    "error": "Bad Request",
    "statusCode": 400
}
```
```json
{
    "message": [
        "Su nueva contraseña no coincide con su confirmación"
    ],
    "error": "Bad Request",
    "statusCode": 400
}
```
```json
{
    "message": [
        "Su contraseña actual y la nueva son identicas"
    ],
    "error": "Bad Request",
    "statusCode": 400
}
```
Agrando a los cambio ajustes a los mensajes en lenguaje español para el usuario final y corrijiendo el linter para escribir el código de manera más legible 